### PR TITLE
simplify environment.yml

### DIFF
--- a/test/environment.yml
+++ b/test/environment.yml
@@ -2,45 +2,14 @@ name: aqua
 channels:
   - conda-forge
 dependencies:
-  - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
-  - bzip2=1.0.8=h7f98852_4
-  - ca-certificates=2022.9.24=ha878542_0
-  - ld_impl_linux-64=2.39=hc81fddc_0
-  - libffi=3.4.2=h7f98852_5
-  - libgcc-ng=12.2.0=h65d4601_18
-  - libgomp=12.2.0=h65d4601_18
-  - libnsl=2.0.0=h7f98852_0
-  - libsqlite=3.39.4=h753d276_0
-  - libuuid=2.32.1=h7f98852_1000
-  - libzlib=1.2.13=h166bdaf_4
-  - ncurses=6.3=h27087fc_1
-  - openssl=3.0.5=h166bdaf_2
-  - pip=22.3=pyhd8ed1ab_0
-  - python=3.10.6=ha86cf86_0_cpython
-  - readline=8.1.2=h0f457ee_0
-  - setuptools=65.5.0=pyhd8ed1ab_0
-  - tk=8.6.12=h27826a3_0
-  - tzdata=2022e=h191b570_0
-  - wheel=0.37.1=pyhd8ed1ab_0
-  - xz=5.2.6=h166bdaf_0
+  - pip
+  - pycodestyle
+  - python=3.10.6
   - pip:
-    - contourpy==1.0.5
-    - cycler==0.11.0
-    - fonttools==4.37.4
-    - imageio==2.22.2
-    - kiwisolver==1.4.4
-    - matplotlib==3.6.1
-    - networkx==2.8.7
-    - numpy==1.23.4
-    - opencv-python==4.6.0.66
-    - packaging==21.3
+    - matplotlib
+    - numpy
+    - opencv-python
     - pillow==9.2.0
-    - pyparsing==3.0.9
-    - python-dateutil==2.8.2
-    - pywavelets==1.4.1
     - scikit-image==0.19.3
     - scipy==1.9.2
-    - six==1.16.0
-    - tifffile==2022.10.10
 prefix: /home/jovyan/.conda/envs/aqua


### PR DESCRIPTION
Simplified environment.yml to be only what we install in the readme (and pycodestyle) and let conda fill out the other dependencies